### PR TITLE
Fixing openjdk8 installation

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.1
 
 LABEL maintainers="Miguel Ángel García <mgarcia.inf@gmail.com>"
 
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get update
 RUN apt-get install -y \
         apt-utils \


### PR DESCRIPTION
Dirty workaround to fix OpenJDK8 installation. Following instructions in this GitHub issue https://github.com/puckel/docker-airflow/issues/182